### PR TITLE
Add `Release Notes` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The object containing your extension information must look like this *(fields th
     
     "source": "Url to the source code",
     "readme": "(optional) readme file",
+    "releases": "(optional) releases page to share release notes"
     
     "stable": true,
     
@@ -90,6 +91,7 @@ Most fields are self-explanatory, but some require extra attention:
 * `categories` describe the type of extension, at least 1 type is required. List of possible categories are to be found in `store/config.json`.
 * `source` is a required field, it must link to your git repository
 * `readme` can point to any URL containing extra information (such as instructions) for your extension, typically it would point to the README file of your repository. It can also be empty or null
+* `releases` can point to any URL containing release notes for your extension, typically it would point to the Releases page of your repository. It can also be empty or null
 * `stable` must be set to `false` if this extension doesn't always show correct behavior. You're required to have this set to `true` in the initial PR. You can change it to `false` later on if it turns out to be unstable and aren't deploying a fix anytime soon
 * `framework.name` must be available in `extension_configTest.json` -> `frameworks`. Possible values currently are `Native` (Java), `G-Python`, `Geode`, `G-Node` and `Xabbo`
 * `framework.version` is the version of the framework at time of compilation *(or at time of writing in case of interpreted languages)*. For `Native`, it is just the version of G-Earth

--- a/scripts/discord/publish-to-discord.js
+++ b/scripts/discord/publish-to-discord.js
@@ -38,6 +38,9 @@ const embedExtension = (ext) => {
     if (ext.readme != null) {
         embed.addField("Readme", `[Click here!](${ext.readme})`, true);
     }
+    if (ext.releases != null) {
+        embed.addField("Release notes", `[Click here!](${ext.releases})`, true);
+    }
     embed
         .addField("Version", ext.version, true)
         .addField("Client", ext.compatibility.clients.join(", "), true)

--- a/scripts/tests/extensions/extension_config.test.js
+++ b/scripts/tests/extensions/extension_config.test.js
@@ -62,6 +62,10 @@ for(const e of extensions) {
         it('may have a readme which is an URL', () => {
             expect(!exists(e.readme) || validURL(e.readme)).toBe(true);
         });
+        
+        it('may have a releases which is an URL', () => {
+            expect(!exists(e.releases) || validURL(e.releases)).toBe(true);
+        });
 
         it('is stable or unstable', () => {
             expect(typeof e.stable).toBe("boolean");

--- a/scripts/twitter/publish-to-twitter.js
+++ b/scripts/twitter/publish-to-twitter.js
@@ -18,11 +18,12 @@ const writeCache = () => {
 
 const publishExtensionTweet = async (client, ext) => {
     const readMore = ext.readme !== undefined ? ` \n\nRead more: ${ext.readme}` : ""
+    const releaseNotes = ext.releases !== undefined ? ` \n\nRelease Notes: ${ext.releases}` : ""
     const author = ext.authors[0];
     const authorInTweet = author.twitter !== undefined ? "@" + author.twitter : author.name;
 
     const tweetContents = `A new extension "${ext.title}" was published to the G-ExtensionStore!` +
-        ` Created by ${authorInTweet}.${readMore}`;
+        ` Created by ${authorInTweet}.${readMore}${releaseNotes}`;
     // const mediaId = await client.v1.uploadMedia('image.png');
 
     const screenshotPath = `./store/extensions/${ext.title}/screenshot.png`;
@@ -38,11 +39,12 @@ const publishExtensionTweet = async (client, ext) => {
 }
 const updateExtensionTweet = async (client, oldVersion, ext) => {
     const readMore = ext.readme !== undefined ? ` \n\nRead more: ${ext.readme}` : ""
+    const releaseNotes = ext.releases !== undefined ? ` \n\nRelease Notes: ${ext.releases}` : ""
     const author = ext.authors[0];
     const authorInTweet = author.twitter !== undefined ? "@" + author.twitter : author.name;
 
     const tweetContents = `"${ext.title}" was updated from ${oldVersion} to ${ext.version}!` +
-        ` Created by ${authorInTweet}.${readMore}`;
+        ` Created by ${authorInTweet}.${readMore}${releaseNotes}`;
 
     console.log(`Updating ${ext.title} on twitter...`)
     return await client.v1.tweet(tweetContents);


### PR DESCRIPTION
I think I've added it in every required location within the G-ExtensionStore repo so it shows up on both Discord and Twitter if a link is present.

And I've also made sure to add it to the tests file which test's the `extension.json` file and added it to the ReadMe.

The only place it might still need to be added is in the actual ExtensionStore extension.