### PR TITLE
Fix all launch commands on Linux & Mac

### DIFF
--- a/store/extensions/Clear Wired Selection/extension.json
+++ b/store/extensions/Clear Wired Selection/extension.json
@@ -26,7 +26,7 @@
   "commands": {
     "default": ["cmd", "/C", "clear-wired-selection.exe", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
     "windows": ["cmd", "/C", "clear-wired-selection.exe", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
-    "mac": ["chmod", "+x", "clear-wired-selection", "&&", "./clear-wired-selection", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"]
+    "mac": ["/bin/sh", "-c", "chmod +x clear-wired-selection && ./clear-wired-selection -p \"$1\" -c \"$2\" -f \"$3\"", "--", "{port}", "{cookie}", "{filename}"]
   },
 
   "compatibility": {

--- a/store/extensions/G-Trader/extension.json
+++ b/store/extensions/G-Trader/extension.json
@@ -25,8 +25,8 @@
   "commands": {
     "default": ["cmd", "/C", "g-trader-win.exe", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
     "windows": ["cmd", "/C", "g-trader-win.exe", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
-    "mac": ["chmod", "+x", "g-trader-mac", "&&", "./g-trader-mac", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
-    "linux": ["chmod", "+x", "g-trader-linux", "&&", "./g-trader-linux", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"]
+    "mac": ["/bin/sh", "-c", "chmod +x g-trader-mac && ./g-trader-mac -p \"$1\" -c \"$2\" -f \"$3\"", "--", "{port}", "{cookie}", "{filename}"],
+    "linux": ["/bin/sh", "-c", "chmod +x g-trader-linux && ./g-trader-linux -p \"$1\" -c \"$2\" -f \"$3\"", "--", "{port}", "{cookie}", "{filename}"]
   },
   
   "compatibility": {

--- a/store/extensions/G-itemViewer/extension.json
+++ b/store/extensions/G-itemViewer/extension.json
@@ -23,7 +23,7 @@
   "commands": {
     "default": ["cmd", "/C", "G-itemViewer.exe", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
     "windows": ["cmd", "/C", "G-itemViewer.exe", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
-    "mac": ["chmod", "+x", "G-itemViewer-mac", "&&", "./G-itemViewwer-mac", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"]
+    "mac": ["/bin/sh", "-c", "chmod +x G-itemViewer-mac && ./G-itemViewer-mac -p \"$1\" -c \"$2\" -f \"$3\"", "--", "{port}", "{cookie}", "{filename}"]
   },
   
   "compatibility": {

--- a/store/extensions/Poker/extension.json
+++ b/store/extensions/Poker/extension.json
@@ -47,29 +47,21 @@
       "{filename}"
     ],
     "mac": [
-      "chmod",
-      "+x",
-      "poker-mac",
-      "&&",
-      "./poker-mac",
+      "/bin/sh",
       "-c",
-      "{cookie}",
-      "-p",
+      "chmod +x poker-mac && ./poker-mac -p \"$1\" -c \"$2\" -f \"$3\"",
+      "--",
       "{port}",
-      "-f",
+      "{cookie}",
       "{filename}"
     ],
     "linux": [
-      "chmod",
-      "+x",
-      "poker-linux",
-      "&&",
-      "./poker-linux",
+      "/bin/sh",
       "-c",
-      "{cookie}",
-      "-p",
+      "chmod +x poker-linux && ./poker-linux -p \"$1\" -c \"$2\" -f \"$3\"",
+      "--",
       "{port}",
-      "-f",
+      "{cookie}",
       "{filename}"
     ]
   },

--- a/store/extensions/Shoutify/extension.json
+++ b/store/extensions/Shoutify/extension.json
@@ -47,29 +47,21 @@
       "{filename}"
     ],
     "mac": [
-      "chmod",
-      "+x",
-      "shoutify-mac",
-      "&&",
-      "./shoutify-mac",
+      "/bin/sh",
       "-c",
-      "{cookie}",
-      "-p",
+      "chmod +x shoutify-mac && ./shoutify-mac -p \"$1\" -c \"$2\" -f \"$3\"",
+      "--",
       "{port}",
-      "-f",
+      "{cookie}",
       "{filename}"
     ],
     "linux": [
-      "chmod",
-      "+x",
-      "shoutify-linux",
-      "&&",
-      "./shoutify-linux",
+      "/bin/sh",
       "-c",
-      "{cookie}",
-      "-p",
+      "chmod +x shoutify-linux && ./shoutify-linux -p \"$1\" -c \"$2\" -f \"$3\"",
+      "--",
       "{port}",
-      "-f",
+      "{cookie}",
       "{filename}"
     ]
   },

--- a/store/extensions/Talk To Shout Origins/extension.json
+++ b/store/extensions/Talk To Shout Origins/extension.json
@@ -29,8 +29,8 @@
   "commands": {
     "default": ["cmd", "/C", "TalkToShout-win.exe", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
     "windows": ["cmd", "/C", "TalkToShout-win.exe", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
-    "mac": ["chmod", "+x", "TalkToShout-mac", "&&", "./TalkToShout-mac", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
-    "linux": ["chmod", "+x", "TalkToShout-linux", "&&", "./TalkToShout-linux", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"]
+    "mac": ["/bin/sh", "-c", "chmod +x TalkToShout-mac && ./TalkToShout-mac -p \"$1\" -c \"$2\" -f \"$3\"", "--", "{port}", "{cookie}", "{filename}"],
+    "linux": ["/bin/sh", "-c", "chmod +x TalkToShout-linux && ./TalkToShout-linux -p \"$1\" -c \"$2\" -f \"$3\"", "--", "{port}", "{cookie}", "{filename}"]
   },
   
   "compatibility": {

--- a/store/extensions/autogarland/extension.json
+++ b/store/extensions/autogarland/extension.json
@@ -26,8 +26,8 @@
   "commands": {
     "default": ["cmd", "/C", "autogarland-win.exe", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
     "windows": ["cmd", "/C", "autogarland-win.exe", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
-    "mac": ["chmod", "+x", "autogarland-mac", "&&", "./fastbuy-mac", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
-    "linux": ["chmod", "+x", "autogarland-linux", "&&", "./fastbuy-linux", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"]
+    "mac": ["/bin/sh", "-c", "chmod +x autogarland-mac && ./autogarland-mac -p \"$1\" -c \"$2\" -f \"$3\"", "--", "{port}", "{cookie}", "{filename}"],
+    "linux": ["/bin/sh", "-c", "chmod +x autogarland-linux && ./autogarland-linux -p \"$1\" -c \"$2\" -f \"$3\"", "--", "{port}", "{cookie}", "{filename}"]
   },
   
   "compatibility": {

--- a/store/extensions/easydice/extension.json
+++ b/store/extensions/easydice/extension.json
@@ -26,8 +26,8 @@
   "commands": {
     "default": ["cmd", "/C", "easydice-win.exe", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
     "windows": ["cmd", "/C", "easydice-win.exe", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
-    "mac": ["chmod", "+x", "easydice-mac", "&&", "./fastbuy-mac", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
-    "linux": ["chmod", "+x", "easydice-linux", "&&", "./fastbuy-linux", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"]
+    "mac": ["/bin/sh", "-c", "chmod +x easydice-mac && ./easydice-mac -p \"$1\" -c \"$2\" -f \"$3\"", "--", "{port}", "{cookie}", "{filename}"],
+    "linux": ["/bin/sh", "-c", "chmod +x easydice-linux && ./easydice-linux -p \"$1\" -c \"$2\" -f \"$3\"", "--", "{port}", "{cookie}", "{filename}"]
   },
   
   "compatibility": {

--- a/store/extensions/fastbuy/extension.json
+++ b/store/extensions/fastbuy/extension.json
@@ -26,8 +26,8 @@
   "commands": {
     "default": ["cmd", "/C", "fastbuy-win.exe", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
     "windows": ["cmd", "/C", "fastbuy-win.exe", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
-    "mac": ["chmod", "+x", "fastbuy-mac", "&&", "./fastbuy-mac", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"],
-    "linux": ["chmod", "+x", "fastbuy-linux", "&&", "./fastbuy-linux", "-c", "{cookie}", "-p", "{port}", "-f", "{filename}"]
+    "mac": ["/bin/sh", "-c", "chmod +x fastbuy-mac && ./fastbuy-mac -p \"$1\" -c \"$2\" -f \"$3\"", "--", "{port}", "{cookie}", "{filename}"],
+    "linux": ["/bin/sh", "-c", "chmod +x fastbuy-linux && ./fastbuy-linux -p \"$1\" -c \"$2\" -f \"$3\"", "--", "{port}", "{cookie}", "{filename}"]
   },
   
   "compatibility": {


### PR DESCRIPTION
This PR fixes the Linux and Mac launch commands for all extensions. `["chmod", "+x", "extension", "&&", "./extension", ...]` fails because it is just passing each string including '&&' as an argument to `chmod` instead of interpreting it as a shell command. I have changed them to use `/bin/sh -c` so that the command is interpreted by the shell.